### PR TITLE
fix release pipeline condition to run only on tagged push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,7 @@ on:
   push:
     tags:
       - v*
-    branches:
-      - master
+
 jobs:
   # even when there are no tests, test job will ensure that project builds successfully
   test:


### PR DESCRIPTION
Spotted that push condition was wrong causing the release pipeline to kick on every push to master instead of only tagged commits